### PR TITLE
Fix build on Windows/MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 cmake-build-*
 build
 **path_*.csv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,33 @@ project(coverage_mission_planner)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(MSVC)
-  add_compile_options(/W4 /WX)
-else()
-  add_compile_options(-Wall -Wextra -pedantic -Werror)
-endif()
-
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
 add_executable(${PROJECT_NAME} src/main.cpp src/MapPolygon.cpp include/MapPolygon.hpp src/utils.cpp src/algorithms.cpp src/EnergyCalculator.cpp src/ShortestPathCalculator.cpp include/ShortestPathCalculator.hpp include/custom_types.hpp include/mstsp_solver/Target.h src/mstsp_solver/TargetSet.cpp include/mstsp_solver/TargetSet.h include/mstsp_solver/SolverConfig.h src/mstsp_solver/MstspSolver.cpp include/mstsp_solver/MstspSolver.h include/mstsp_solver/Insertion.h include/SimpleLogger.h include/LoggerRos.h)
 
-find_package(yaml-cpp)
+if(MSVC)
+  target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /D_USE_MATH_DEFINES)
+else()
+  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -Werror)
+endif()
+
+include(FetchContent)
+
+FetchContent_Declare(
+  yaml-cpp
+  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+  GIT_TAG 0.8.0
+)
+FetchContent_GetProperties(yaml-cpp)
+
+if(NOT yaml-cpp_POPULATED)
+  message(STATUS "Fetching yaml-cpp...")
+  FetchContent_Populate(yaml-cpp)
+  add_subdirectory(${yaml-cpp_SOURCE_DIR} ${yaml-cpp_BINARY_DIR})
+endif()
 
 
-target_include_directories(${PROJECT_NAME} PUBLIC include ${YAML_CPP_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PRIVATE yaml-cpp::yaml-cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE include)

--- a/include/mstsp_solver/TargetSet.h
+++ b/include/mstsp_solver/TargetSet.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include "Target.h"
 #include <cmath>
+#include <math.h>
 #include "MapPolygon.hpp"
 #include "EnergyCalculator.h"
 

--- a/src/MapPolygon.cpp
+++ b/src/MapPolygon.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <cmath>
 #include "algorithms.hpp"
+#include <math.h>
 
 // TODO: make most of methods external functions (maybe, working on not MapPolygons but just on vector<pair<double, double>>
 // TODO: make use of some external polygons library like
@@ -242,7 +243,7 @@ std::vector<MapPolygon> MapPolygon::split_into_pieces(double max_piece_area) {
 
     try {
 
-        int res_polygons = std::ceil(area() / max_piece_area);
+        auto res_polygons = static_cast<int>(std::ceil(area() / max_piece_area));
         double split_piece_area = area() / res_polygons;
         auto cur_polygon = *this;
         std::vector<MapPolygon> res;
@@ -269,7 +270,7 @@ std::vector<MapPolygon> MapPolygon::split_into_pieces(double max_piece_area) {
         }
         res.push_back(cur_polygon);
         return res;
-    } catch (std::runtime_error &e) {
+    } catch (std::runtime_error &) {
 //        m_logger->log_err("[PathGenerator]: ERROR while dividing polygon: " + std::string(e.what()));
     }
     return {};
@@ -328,7 +329,7 @@ namespace {
         }
         double l = 0, r = largest_area;
         auto current_num_of_pols = sub_polygons.size();
-        while (r - l > 1 and current_num_of_pols != n) {
+        while (r - l > 1 && current_num_of_pols != n) {
             double m = (r + l) / 2;
             size_t number_of_decomposed = 0;
             for (auto &pol: sub_polygons) {

--- a/src/ShortestPathCalculator.cpp
+++ b/src/ShortestPathCalculator.cpp
@@ -89,7 +89,7 @@ ShortestPathCalculator::ShortestPathCalculator(const MapPolygon &polygon) {
     // And 2-d matrix for the Floyd-Warshall algorithm
     m_next_vertex_in_path = std::vector<std::vector<size_t>>(m_polygon_points.size());
     std::for_each(m_next_vertex_in_path.begin(), m_next_vertex_in_path.end(),
-                  [&](auto &row) { row = std::vector<size_t>(m_polygon_points.size(), -1); });
+                  [&](auto &row) { row = std::vector<size_t>(m_polygon_points.size(), ~static_cast<size_t>(0)); });
     m_floyd_warshall_d = std::vector<std::vector<double>>(m_polygon_points.size());
     std::for_each(m_floyd_warshall_d.begin(), m_floyd_warshall_d.end(),
                   [&](auto &row) { row = std::vector<double>(m_polygon_points.size(), HUGE_VAL); });

--- a/src/algorithms.cpp
+++ b/src/algorithms.cpp
@@ -155,7 +155,7 @@ vpdd thin_polygon_coverage(const MapPolygon &polygon, double sweeping_step, doub
 
 vpdd sweeping(const MapPolygon &polygon, double angle, double sweeping_step, double wall_distance, bool start_up) {
     auto thin_sweeping = thin_polygon_coverage(polygon, sweeping_step, wall_distance);
-    if (not thin_sweeping.empty()) {
+    if (!thin_sweeping.empty()) {
         return thin_sweeping;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
         };
         best_solution = generate_with_constraints(algorithm_config.max_single_path_energy * 3600,
                                                   algorithm_config.number_of_drones, f);
-    } catch (const polygon_decomposition_error &e) {
+    } catch (const polygon_decomposition_error &) {
         std::cout << "Error while decomposing the polygon" << std::endl;
         return -1;
     } catch (const std::runtime_error &e) {
@@ -187,7 +187,7 @@ generate_with_constraints(double max_energy_bound, unsigned int n_uavs, F f) {
             return solution;
         }
         // if the energy consumption is divided well, this should be enough
-        unsigned int updated_n_uavs = std::ceil(solution.path_energies_sum / max_energy_bound);
+        auto updated_n_uavs = static_cast<unsigned int>(std::ceil(solution.path_energies_sum / max_energy_bound));
 
         // if the needed number of UAVs is estimated to be smaller than on previous step, make it larger
         if (updated_n_uavs <= current_n_uavs) {
@@ -227,7 +227,7 @@ std::vector<point_t> read_points_from_csv(const std::string &filename) {
 
     is.close();
     // Make sure that the first point is always the same as the last one
-    if (not points.empty() and points[0] != points[points.size() - 1]) {
+    if (!points.empty() && points[0] != points[points.size() - 1]) {
         points.push_back(points[0]);
     }
     return points;


### PR DESCRIPTION
A couple of fixes for building in MSVC:
- Add `math.h` includes where M_PI constants are used, with the `_USE_MATH_DEFINES` compile definition
- Use `target_compile_options` instead of `add_compile_definitions` so that warnings on the yaml library don't affect the executable compilation
- Use `FetchContent` instead of `find_package` so that users don't need to have the yaml package installed
- Fix some conversions and warnings
- Avoid the usage of alternative operators